### PR TITLE
Add error output for build.rs CMake build step

### DIFF
--- a/gpt4all-bindings/rust/build.rs
+++ b/gpt4all-bindings/rust/build.rs
@@ -136,7 +136,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let symlink_path = canonized_lib_folder.join("libllmodel.so.0");
         let target_path = canonized_lib_folder.join("libllmodel.so");
-        std::os::unix::fs::symlink(target_path, symlink_path)?;
+        std::os::unix::fs::symlink(target_path, symlink_path).ok();
     }
 
     // Tell cargo to look for shared libraries in the specified directory

--- a/gpt4all-bindings/rust/build.rs
+++ b/gpt4all-bindings/rust/build.rs
@@ -25,6 +25,12 @@ fn build_cmake_backend_project(backend_source_path: &PathBuf, build_dir_path: &P
         .output()?;
 
     if !cmake_build.status.success() {
+        if let Ok(str) = std::str::from_utf8(&cmake_build.stdout) {
+            println!("{}", str);
+        }
+        if let Ok(str) = std::str::from_utf8(&cmake_build.stderr) {
+            eprintln!("{}", str);
+        }
         return Err(format!("Failed to generate build files: {}", cmake_build.status).into());
     }
 
@@ -110,7 +116,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let build_dir_path = out_dir_path.join("build");
 
     // Build C Lib
-    build_cmake_backend_project(&backend_source_path, &build_dir_path)?;
+    if let Err(e) = build_cmake_backend_project(&backend_source_path, &build_dir_path) {
+        eprintln!("Failed to build backend project with CMake");
+        return Err(e);
+    }
 
     let canonized_lib_folder = build_dir_path
         // Canonicalize the path as `rustc-link-search` requires an absolute


### PR DESCRIPTION
Heya! Just a small PR to improve a bit on the error output of `build.rs` itself to give it a bit more context.

**Note:** If (or regardless of) merging this, I guess this [DCO Check fix](https://github.com/nomic-ai/gpt4all/pull/2247/checks?check_run_id=24206718712) from nomic-ai/gpt4all#2247 should be applied.

## CMake error output

This change mainly turns:

```plain
  --- stderr
  Error: "Failed to generate build files: exit status: 1"
```

into

```plain
  --- stdout
  -- The CXX compiler identification is GNU 13.2.0
  -- The C compiler identification is GNU 13.2.0
  -- Detecting CXX compiler ABI info
  -- Detecting CXX compiler ABI info - done
  -- Check for working CXX compiler: /usr/bin/c++ - skipped
  -- Detecting CXX compile features
  -- Detecting CXX compile features - done
  -- Detecting C compiler ABI info
  -- Detecting C compiler ABI info - done
  -- Check for working C compiler: /usr/bin/cc - skipped
  -- Detecting C compile features
  -- Detecting C compile features - done
  -- Interprocedural optimization support detected
  -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
  -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
  -- Found Threads: TRUE
  -- Kompute found
  -- Configuring incomplete, errors occurred!


  --- stderr
  CMake Error at /usr/share/cmake-3.29/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
    Could NOT find Vulkan (missing: glslc) (found version "1.3.275")
  Call Stack (most recent call first):
    /usr/share/cmake-3.29/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
    /usr/share/cmake-3.29/Modules/FindVulkan.cmake:594 (find_package_handle_standard_args)
    llama.cpp.cmake:170 (find_package)
    CMakeLists.txt:42 (include)



  Failed to build backend project with CMake
  Error: "Failed to generate build files: exit status: 1"
```

It's much more verbose in the error case but it makes it possible to find the underlying problem, in my case `Could NOT find Vulkan` because of a missing `glslc`.

## Symlinking Error

There may be a situation on Linux builds where the symlinked file already exists from a previous build. This type of error is now silently ignored by a `.ok()`. It's not optimal, but at least better than seeing a warning on every build.