### PR TITLE
GitHub Actions for building and testing the Rust bindings

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-ignore-words-list = blong, afterall, som, assistent, crasher
+ignore-words-list = blong, afterall, som, assistent, crasher, crate
 skip = .git,*.pdf,*.svg,*.lock

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -14,6 +14,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,77 @@
+---
+name: Rust
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'gpt4all-backend/**'
+      - 'gpt4all-bindings/rust/Cargo.toml'
+      - 'gpt4all-bindings/rust/Cargo.lock'
+      - 'gpt4all-bindings/rust/build.rs'
+      - 'gpt4all-bindings/rust/src/**'
+      - '.github/workflows/rust.yml'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'gpt4all-backend/**'
+      - 'gpt4all-bindings/rust/Cargo.toml'
+      - 'gpt4all-bindings/rust/Cargo.lock'
+      - 'gpt4all-bindings/rust/build.rs'
+      - 'gpt4all-bindings/rust/src/**'
+      - '.github/workflows/rust.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+      - name: Check format
+        working-directory: gpt4all-bindings/rust
+        run: cargo fmt --check
+      - name: Clippy
+        working-directory: gpt4all-bindings/rust
+        run: cargo clippy
+
+  build:
+    name: Build and Test (ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install GLSL Shader Compiler
+        # https://ubuntu.pkgs.org/23.10/ubuntu-universe-amd64/libshaderc1_2023.2-1_amd64.deb.html
+        # https://ubuntu.pkgs.org/23.10/ubuntu-universe-amd64/glslc_2023.2-1_amd64.deb.html
+        run: |
+          curl -L http://archive.ubuntu.com/ubuntu/pool/universe/s/shaderc/libshaderc1_2023.2-1_amd64.deb -o libshaderc.deb
+          curl -L http://archive.ubuntu.com/ubuntu/pool/universe/s/shaderc/glslc_2023.2-1_amd64.deb -o glslc.deb
+          sudo dpkg -i libshaderc.deb
+          sudo dpkg -i glslc.deb
+      - name: Install Vulkan SDK and GLSL Tools
+        run: sudo apt-get install libvulkan-dev glslang-tools
+      - name: Find NVIDIA CUDA Toolkit
+        run: sudo apt-cache search cuda-toolkit
+      - name: Install NVIDIA CUDA Toolkit
+        # run: sudo apt-get install cuda-toolkit-12-5
+        run: sudo apt-get install nvidia-cuda-toolkit
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build
+        working-directory: gpt4all-bindings/rust
+        env:
+          KOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK: 'ON'
+        run: cargo build --verbose
+      - name: Run tests
+        working-directory: gpt4all-bindings/rust
+        run: cargo test --tests --verbose --all-features
+      - name: Run doctests
+        working-directory: gpt4all-bindings/rust
+        run: cargo test --doc --verbose --all-features

--- a/gpt4all-bindings/rust/.gitignore
+++ b/gpt4all-bindings/rust/.gitignore
@@ -1,1 +1,2 @@
 target
+Cargo.lock

--- a/gpt4all-bindings/rust/Cargo.toml
+++ b/gpt4all-bindings/rust/Cargo.toml
@@ -23,7 +23,7 @@ dirs = "5.0.1"
 
 [lib]
 name = "gpt4all"
-crate-type = ["dylib"]
+crate-type = ["dylib", "rlib"]
 
 [build-dependencies]
 bindgen = "0.69.4"

--- a/gpt4all-bindings/rust/build.rs
+++ b/gpt4all-bindings/rust/build.rs
@@ -136,7 +136,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let symlink_path = canonized_lib_folder.join("libllmodel.so.0");
         let target_path = canonized_lib_folder.join("libllmodel.so");
-        std::os::unix::fs::symlink(target_path, symlink_path)?;
+        std::os::unix::fs::symlink(target_path, symlink_path).ok();
     }
 
     // Tell cargo to look for shared libraries in the specified directory

--- a/gpt4all-bindings/rust/build.rs
+++ b/gpt4all-bindings/rust/build.rs
@@ -25,6 +25,12 @@ fn build_cmake_backend_project(backend_source_path: &PathBuf, build_dir_path: &P
         .output()?;
 
     if !cmake_build.status.success() {
+        if let Ok(str) = std::str::from_utf8(&cmake_build.stdout) {
+            println!("{}", str);
+        }
+        if let Ok(str) = std::str::from_utf8(&cmake_build.stderr) {
+            eprintln!("{}", str);
+        }
         return Err(format!("Failed to generate build files: {}", cmake_build.status).into());
     }
 
@@ -110,7 +116,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let build_dir_path = out_dir_path.join("build");
 
     // Build C Lib
-    build_cmake_backend_project(&backend_source_path, &build_dir_path)?;
+    if let Err(e) = build_cmake_backend_project(&backend_source_path, &build_dir_path) {
+        eprintln!("Failed to build backend project with CMake");
+        return Err(e);
+    }
 
     let canonized_lib_folder = build_dir_path
         // Canonicalize the path as `rustc-link-search` requires an absolute

--- a/gpt4all-bindings/rust/src/wrappers/completion/domain.rs
+++ b/gpt4all-bindings/rust/src/wrappers/completion/domain.rs
@@ -247,7 +247,7 @@ impl CompletionRequestBuilder {
 /// Example 1: Mistral OpenOrca
 ///
 /// ```
-///
+/// # use gpt4all::wrappers::completion::domain::SystemDescription;
 /// let system_description = SystemDescription {
 ///     system_prompt: "system\nYou are MistralOrca, a large language model trained by Alignment Lab AI.\n\n".to_string(),
 /// };
@@ -256,7 +256,7 @@ impl CompletionRequestBuilder {
 /// Example 2: Mini Orca (Small)
 ///
 /// ```
-///
+/// # use gpt4all::wrappers::completion::domain::SystemDescription;
 /// let system_description = SystemDescription {
 ///     system_prompt: "### System:\nYou are an AI assistant that follows instruction extremely well. Help as much as you can.\n\n".to_string(),
 /// };


### PR DESCRIPTION
This piggy-packs off #1 for the builds on Linux and otherwise adds GitHub Actions for building the Rust bindings and running the tests as was suggested in https://github.com/nomic-ai/gpt4all/pull/2247#pullrequestreview-2050338841. The builds take forever, and I only targeted the `ubuntu-latest` runner since I don't know how to set it up on MacOS runners.

I also added a linter/formatting step that will report but is allowed to fail. I didn't actually want to address these fixes here - seemed overkill.